### PR TITLE
Enable endpoint to view templates

### DIFF
--- a/src/main/java/org/codeforamerica/messaging/controllers/TemplateController.java
+++ b/src/main/java/org/codeforamerica/messaging/controllers/TemplateController.java
@@ -1,0 +1,39 @@
+package org.codeforamerica.messaging.controllers;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codeforamerica.messaging.models.Template;
+import org.codeforamerica.messaging.services.TemplateService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Optional;
+
+@RestController
+@RequestMapping(("/api/v1/templates"))
+public class TemplateController {
+    private final TemplateService templateService;
+
+    public TemplateController(TemplateService templateService) {
+        this.templateService = templateService;
+    }
+
+    @GetMapping()
+    public ResponseEntity<List<Template>> getTemplateList(@RequestParam(required = false) String name) {
+        if (StringUtils.isNotEmpty(name)) {
+            Optional<Template> template = templateService.getTemplateByName(name);
+            return template.map(value -> ResponseEntity.ok(List.of(value))).orElseGet(() -> ResponseEntity.notFound().build());
+        }
+        List<Template> templateList = templateService.getTemplateList();
+        if (templateList.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(templateList);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Template> getTemplateById(@PathVariable Long id) {
+        Optional<Template> template = templateService.getTemplateById(id);
+        return template.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+}

--- a/src/main/java/org/codeforamerica/messaging/controllers/TemplateController.java
+++ b/src/main/java/org/codeforamerica/messaging/controllers/TemplateController.java
@@ -1,10 +1,12 @@
 package org.codeforamerica.messaging.controllers;
 
-import org.apache.commons.lang3.StringUtils;
 import org.codeforamerica.messaging.models.Template;
 import org.codeforamerica.messaging.services.TemplateService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 import java.util.Optional;
@@ -19,21 +21,14 @@ public class TemplateController {
     }
 
     @GetMapping()
-    public ResponseEntity<List<Template>> getTemplateList(@RequestParam(required = false) String name) {
-        if (StringUtils.isNotEmpty(name)) {
-            Optional<Template> template = templateService.getTemplateByName(name);
-            return template.map(value -> ResponseEntity.ok(List.of(value))).orElseGet(() -> ResponseEntity.notFound().build());
-        }
+    public ResponseEntity<List<Template>> getTemplateList() {
         List<Template> templateList = templateService.getTemplateList();
-        if (templateList.isEmpty()) {
-            return ResponseEntity.notFound().build();
-        }
-        return ResponseEntity.ok(templateList);
+        return templateList.isEmpty() ? ResponseEntity.notFound().build() : ResponseEntity.ok(templateService.getTemplateList());
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<Template> getTemplateById(@PathVariable Long id) {
-        Optional<Template> template = templateService.getTemplateById(id);
+    @GetMapping("/{name}")
+    public ResponseEntity<Template> getTemplateByName(@PathVariable String name) {
+        Optional<Template> template = templateService.getTemplateByName(name);
         return template.map(ResponseEntity::ok).orElseGet(() -> ResponseEntity.notFound().build());
     }
 }

--- a/src/main/java/org/codeforamerica/messaging/models/Message.java
+++ b/src/main/java/org/codeforamerica/messaging/models/Message.java
@@ -3,6 +3,7 @@ package org.codeforamerica.messaging.models;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -24,6 +25,7 @@ public class Message {
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
     @ManyToOne
+    @NotNull
     TemplateVariant templateVariant;
     @Pattern(regexp = RegexPatternStrings.PHONE_NUMBER_REGEX)
     String toPhone;
@@ -40,6 +42,10 @@ public class Message {
     private OffsetDateTime creationTimestamp;
     @UpdateTimestamp
     private OffsetDateTime updateTimestamp;
+
+    public String getTemplateName() {
+        return templateVariant.getTemplateName();
+    }
 
     public boolean needToSendEmail() {
         return toEmail != null && emailMessage == null;

--- a/src/main/java/org/codeforamerica/messaging/models/Template.java
+++ b/src/main/java/org/codeforamerica/messaging/models/Template.java
@@ -33,16 +33,12 @@ public class Template {
     @UpdateTimestamp
     private OffsetDateTime updateTimestamp;
 
-    public void addTemplateVariant(TemplateVariant templateVariant) {
+    public TemplateVariant addTemplateVariant(TemplateVariant.TemplateVariantBuilder templateVariantBuilder) {
         if (templateVariants.isEmpty()) {
             this.setTemplateVariants(new LinkedList<>());
         }
+        TemplateVariant templateVariant = templateVariantBuilder.template(this).build();
         templateVariants.add(templateVariant);
-        templateVariant.setTemplate(this);
-    }
-
-    public void removeTemplateVariant(TemplateVariant templateVariant) {
-        templateVariants.remove(templateVariant);
-        templateVariant.setTemplate(null);
+        return templateVariant;
     }
 }

--- a/src/main/java/org/codeforamerica/messaging/models/Template.java
+++ b/src/main/java/org/codeforamerica/messaging/models/Template.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.OffsetDateTime;
+import java.util.LinkedList;
 import java.util.List;
 
 @Entity
@@ -23,10 +24,25 @@ public class Template {
     @Column(unique=true)
     @ToString.Include
     String name;
-    @OneToMany(mappedBy = "template", fetch = FetchType.EAGER, cascade = CascadeType.ALL)
-    List<TemplateVariant> templateVariants;
+    @ToString.Include
+    @Singular
+    @OneToMany(mappedBy = "template", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
+    List<TemplateVariant> templateVariants = new LinkedList<>();
     @CreationTimestamp
     private OffsetDateTime creationTimestamp;
     @UpdateTimestamp
     private OffsetDateTime updateTimestamp;
+
+    public void addTemplateVariant(TemplateVariant templateVariant) {
+        if (templateVariants.isEmpty()) {
+            this.setTemplateVariants(new LinkedList<>());
+        }
+        templateVariants.add(templateVariant);
+        templateVariant.setTemplate(this);
+    }
+
+    public void removeTemplateVariant(TemplateVariant templateVariant) {
+        templateVariants.remove(templateVariant);
+        templateVariant.setTemplate(null);
+    }
 }

--- a/src/main/java/org/codeforamerica/messaging/models/Template.java
+++ b/src/main/java/org/codeforamerica/messaging/models/Template.java
@@ -25,7 +25,7 @@ public class Template {
     @ToString.Include
     String name;
     @ToString.Include
-    @Singular
+    @Builder.Default
     @OneToMany(mappedBy = "template", fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
     List<TemplateVariant> templateVariants = new LinkedList<>();
     @CreationTimestamp
@@ -33,12 +33,13 @@ public class Template {
     @UpdateTimestamp
     private OffsetDateTime updateTimestamp;
 
-    public TemplateVariant addTemplateVariant(TemplateVariant.TemplateVariantBuilder templateVariantBuilder) {
-        if (templateVariants.isEmpty()) {
-            this.setTemplateVariants(new LinkedList<>());
-        }
-        TemplateVariant templateVariant = templateVariantBuilder.template(this).build();
-        templateVariants.add(templateVariant);
-        return templateVariant;
+    public void addTemplateVariant(TemplateVariant templateVariant) {
+        this.templateVariants.add(templateVariant);
+        templateVariant.setTemplate(this);
+    }
+
+    public void removeTemplateVariant(TemplateVariant templateVariant) {
+        this.templateVariants.remove(templateVariant);
+        templateVariant.setTemplate(null);
     }
 }

--- a/src/main/java/org/codeforamerica/messaging/models/TemplateVariant.java
+++ b/src/main/java/org/codeforamerica/messaging/models/TemplateVariant.java
@@ -1,5 +1,6 @@
 package org.codeforamerica.messaging.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.jknack.handlebars.Handlebars;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
@@ -25,23 +26,30 @@ public class TemplateVariant {
     @Id
     @GeneratedValue(strategy= GenerationType.IDENTITY)
     private Long id;
-    String subject;
-    @NotBlank
-    String body;
     @NotBlank
     @Builder.Default
     String language = DEFAULT_LANGUAGE;
     @NotBlank
     @Builder.Default
     String treatment = DEFAULT_TREATMENT;
+    String subject;
+    @NotBlank
+    String body;
     @ManyToOne
+    @JsonIgnore
+    @ToString.Exclude
     Template template;
+    @JsonIgnore
     @CreationTimestamp
     @ToString.Exclude
     private OffsetDateTime creationTimestamp;
     @UpdateTimestamp
     @ToString.Exclude
     private OffsetDateTime updateTimestamp;
+
+    public String getTemplateName() {
+        return template.getName();
+    }
 
     public String build(Function<TemplateVariant, String> templateFieldGetter, Map<String, Object> templateParams) throws IOException {
         Handlebars handlebars = new Handlebars();

--- a/src/main/java/org/codeforamerica/messaging/models/TemplateVariant.java
+++ b/src/main/java/org/codeforamerica/messaging/models/TemplateVariant.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.github.jknack.handlebars.Handlebars;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
@@ -36,6 +37,7 @@ public class TemplateVariant {
     @NotBlank
     String body;
     @ManyToOne
+    @NotNull
     @JsonIgnore
     @ToString.Exclude
     Template template;

--- a/src/main/java/org/codeforamerica/messaging/models/TemplateVariant.java
+++ b/src/main/java/org/codeforamerica/messaging/models/TemplateVariant.java
@@ -41,14 +41,16 @@ public class TemplateVariant {
     @JsonIgnore
     @ToString.Exclude
     Template template;
-    @JsonIgnore
     @CreationTimestamp
+    @JsonIgnore
     @ToString.Exclude
     private OffsetDateTime creationTimestamp;
     @UpdateTimestamp
+    @JsonIgnore
     @ToString.Exclude
     private OffsetDateTime updateTimestamp;
 
+    @JsonIgnore
     public String getTemplateName() {
         return template.getName();
     }

--- a/src/main/java/org/codeforamerica/messaging/providers/twilio/TwilioGateway.java
+++ b/src/main/java/org/codeforamerica/messaging/providers/twilio/TwilioGateway.java
@@ -13,7 +13,7 @@ import java.time.ZonedDateTime;
 @Slf4j
 public class TwilioGateway {
 
-    public static final String DEFAULT_NUMBER = "0000000000";
+    public static final String DEFAULT_FROM_PHONE = "0000000000";
     @Value("${twilio.account.sid}")
     private String twilioAccountSid;
     @Value("${twilio.auth.token}")
@@ -35,7 +35,7 @@ public class TwilioGateway {
                         .create();
 
         return SmsMessage.builder()
-                .fromPhone(DEFAULT_NUMBER)
+                .fromPhone(DEFAULT_FROM_PHONE)
                 .toPhone(twilioMessage.getTo())
                 .body(twilioMessage.getBody())
                 .providerMessageId(twilioMessage.getSid())

--- a/src/main/java/org/codeforamerica/messaging/repositories/TemplateRepository.java
+++ b/src/main/java/org/codeforamerica/messaging/repositories/TemplateRepository.java
@@ -4,7 +4,9 @@ import org.codeforamerica.messaging.models.Template;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface TemplateRepository extends CrudRepository<Template, Long> {
-    Template findFirstByNameIgnoreCase(String name);
+    Optional<Template> findFirstByNameIgnoreCase(String name);
 }

--- a/src/main/java/org/codeforamerica/messaging/services/MessageService.java
+++ b/src/main/java/org/codeforamerica/messaging/services/MessageService.java
@@ -90,14 +90,14 @@ public class MessageService {
     }
 
     private TemplateVariant getTemplateVariant(MessageRequest messageRequest) {
-        Template template = templateRepository.findFirstByNameIgnoreCase(messageRequest.getTemplateName().strip());
-        if (template == null) {
+        Optional<Template> templateOptional = templateRepository.findFirstByNameIgnoreCase(messageRequest.getTemplateName().strip());
+        if (templateOptional.isEmpty()) {
             throw new RuntimeException(String.format(
                     "Template not found with the name provided: name=%s", messageRequest.getTemplateName()));
         }
         String language = messageRequest.getLanguage();
         String treatment = messageRequest.getTreatment();
-        Optional<TemplateVariant> templateVariantOptional = template.getTemplateVariants().stream()
+        Optional<TemplateVariant> templateVariantOptional = templateOptional.get().getTemplateVariants().stream()
                 .filter(templateVariant -> language.equals(templateVariant.getLanguage()))
                 .filter(templateVariant -> treatment.equals(templateVariant.getTreatment()))
                 .findFirst();

--- a/src/main/java/org/codeforamerica/messaging/services/MessageService.java
+++ b/src/main/java/org/codeforamerica/messaging/services/MessageService.java
@@ -73,12 +73,13 @@ public class MessageService {
             if (message.needToSendSms()) {
                 SmsMessage sentSmsMessage = this.smsService.sendSmsMessage(message.getToPhone(), message.getBody());
                 message.setSmsMessage(sentSmsMessage);
+                messageRepository.save(message);
             }
             if (message.needToSendEmail()) {
                 EmailMessage sentEmailMessage = this.emailService.sendEmailMessage(message.getToEmail(), message.getBody(), message.getSubject());
                 message.setEmailMessage(sentEmailMessage);
+                messageRepository.save(message);
             }
-            messageRepository.save(message);
         } catch (Exception e) {
             log.error("Error running job", e);
             throw e;

--- a/src/main/java/org/codeforamerica/messaging/services/TemplateService.java
+++ b/src/main/java/org/codeforamerica/messaging/services/TemplateService.java
@@ -1,0 +1,32 @@
+package org.codeforamerica.messaging.services;
+
+import lombok.extern.slf4j.Slf4j;
+import org.codeforamerica.messaging.models.Template;
+import org.codeforamerica.messaging.repositories.TemplateRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class TemplateService {
+
+    private final TemplateRepository templateRepository;
+
+    public TemplateService(TemplateRepository templateRepository) {
+        this.templateRepository = templateRepository;
+    }
+
+    public List<Template> getTemplateList() {
+        return (List<Template>) templateRepository.findAll();
+    }
+
+    public Optional<Template> getTemplateById(Long id) {
+        return templateRepository.findById(id);
+    }
+
+    public Optional<Template> getTemplateByName(String name) {
+        return templateRepository.findFirstByNameIgnoreCase(name.strip());
+    }
+}

--- a/src/main/resources/db/migration/common/V3__Create_template_and_message_tables.sql
+++ b/src/main/resources/db/migration/common/V3__Create_template_and_message_tables.sql
@@ -14,7 +14,7 @@ create table template_variant
     body                    text                                    not null,
     language                text                                    not null,
     treatment               text                                    not null,
-    template_id             bigint,
+    template_id             bigint                                  not null,
     creation_timestamp      timestamp with time zone                not null,
     update_timestamp        timestamp with time zone,
     primary key (id),

--- a/src/main/resources/db/migration/common/V3__Create_template_and_message_tables.sql
+++ b/src/main/resources/db/migration/common/V3__Create_template_and_message_tables.sql
@@ -14,7 +14,7 @@ create table template_variant
     body                    text                                    not null,
     language                text                                    not null,
     treatment               text                                    not null,
-    template_id             bigint                                  not null,
+    template_id             bigint,
     creation_timestamp      timestamp with time zone                not null,
     update_timestamp        timestamp with time zone,
     primary key (id),

--- a/src/test/java/org/codeforamerica/messaging/MessagingApplicationTests.java
+++ b/src/test/java/org/codeforamerica/messaging/MessagingApplicationTests.java
@@ -2,6 +2,7 @@ package org.codeforamerica.messaging;
 
 import org.assertj.core.api.Assertions;
 import org.codeforamerica.messaging.controllers.MessageController;
+import org.codeforamerica.messaging.controllers.TemplateController;
 import org.codeforamerica.messaging.providers.mailgun.MailgunCallbackController;
 import org.codeforamerica.messaging.providers.twilio.TwilioCallbackController;
 import org.junit.jupiter.api.Test;
@@ -14,6 +15,8 @@ class MessagingApplicationTests {
     @Autowired
     private MessageController messageController;
     @Autowired
+    private TemplateController templateController;
+    @Autowired
     private TwilioCallbackController twilioCallbackController;
     @Autowired
     private MailgunCallbackController mailgunCallbackController;
@@ -21,6 +24,7 @@ class MessagingApplicationTests {
     @Test
     public void contextLoads() {
         Assertions.assertThat(messageController).isNotNull();
+        Assertions.assertThat(templateController).isNotNull();
         Assertions.assertThat(twilioCallbackController).isNotNull();
         Assertions.assertThat(mailgunCallbackController).isNotNull();
     }

--- a/src/test/java/org/codeforamerica/messaging/TestData.java
+++ b/src/test/java/org/codeforamerica/messaging/TestData.java
@@ -1,18 +1,19 @@
 package org.codeforamerica.messaging;
 
-import org.codeforamerica.messaging.models.Template;
-import org.codeforamerica.messaging.models.TemplateVariant;
+import org.codeforamerica.messaging.models.*;
+import org.codeforamerica.messaging.providers.twilio.TwilioGateway;
 
 import java.time.OffsetDateTime;
 import java.util.HashSet;
+import java.util.Map;
 
 public class TestData {
     public static final String TO_PHONE = "1234567890";
     public static final String TO_EMAIL = "recipient@example.com";
+    public static final String FROM_EMAIL = "sender@example.com";
     public static final String PROVIDER_MESSAGE_ID = "some-provider-message-id";
     public static final String STATUS = "accepted";
     public static final String TEMPLATE_NAME = "default template name";
-    public static final String TEMPLATE_NAME_WITH_VARIANTS = "default template name with variants";
     public static final String TEMPLATE_SUBJECT_DEFAULT = "English A Subject: {{placeholder}}";
     public static final String TEMPLATE_BODY_DEFAULT = "English A Body: {{placeholder}}";
     public static final String TEMPLATE_SUBJECT_EN_B = "English B Subject: {{placeholder}}";
@@ -66,12 +67,36 @@ public class TestData {
                 .creationTimestamp(OffsetDateTime.now());
     }
 
-    public static Template addVariantsToTemplate(Template template) {
+    public static void addVariantsToTemplate(Template template) {
         template.addTemplateVariant(aDefaultTemplateVariant().build());
         template.addTemplateVariant(anEnglishBTemplateVariant().build());
         template.addTemplateVariant(aSpanishATemplateVariant().build());
         template.addTemplateVariant(aSpanishBTemplateVariant().build());
-        return template;
+    }
+
+    public static MessageRequest.MessageRequestBuilder aMessageRequest() {
+        return MessageRequest.builder()
+                .templateName(TestData.TEMPLATE_NAME)
+                .templateParams(Map.of("placeholder", "{{placeholder}}"));
+    }
+
+    public static SmsMessage.SmsMessageBuilder anSmsMessage() {
+        return SmsMessage.builder()
+                .body(TestData.TEMPLATE_BODY_DEFAULT)
+                .toPhone(TestData.TO_PHONE)
+                .fromPhone(TwilioGateway.DEFAULT_FROM_PHONE)
+                .status(TestData.STATUS)
+                .providerMessageId(TestData.PROVIDER_MESSAGE_ID);
+    }
+
+    public static EmailMessage.EmailMessageBuilder anEmailMessage() {
+        return EmailMessage.builder()
+                .body(TestData.TEMPLATE_BODY_DEFAULT)
+                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT)
+                .toEmail(TestData.TO_EMAIL)
+                .fromEmail(TestData.FROM_EMAIL)
+                .status(TestData.STATUS)
+                .providerMessageId(TestData.PROVIDER_MESSAGE_ID);
     }
 
 }

--- a/src/test/java/org/codeforamerica/messaging/TestData.java
+++ b/src/test/java/org/codeforamerica/messaging/TestData.java
@@ -3,7 +3,6 @@ package org.codeforamerica.messaging;
 import org.codeforamerica.messaging.models.*;
 import org.codeforamerica.messaging.providers.twilio.TwilioGateway;
 
-import java.time.OffsetDateTime;
 import java.util.Map;
 
 public class TestData {
@@ -16,35 +15,29 @@ public class TestData {
     public static final String TEMPLATE_NAME = "default template name";
     public static final String TEMPLATE_SUBJECT_DEFAULT = "English A Subject: {{placeholder}}";
     public static final String TEMPLATE_BODY_DEFAULT = "English A Body: {{placeholder}}";
-    public static final String TEMPLATE_SUBJECT_EN_B = "English B Subject: {{placeholder}}";
-    public static final String TEMPLATE_BODY_EN_B = "English B Body: {{placeholder}}";
-    public static final String TEMPLATE_SUBJECT_ES_A = "Spanish A Subject: {{placeholder}}";
-    public static final String TEMPLATE_BODY_ES_A = "Spanish A Body: {{placeholder}}";
     public static final String TEMPLATE_SUBJECT_ES_B = "Spanish B Subject: {{placeholder}}";
     public static final String TEMPLATE_BODY_ES_B = "Spanish B Body: {{placeholder}}";
 
-    public static TemplateVariant aDefaultTemplateVariant(Template template) {
-        return template.addTemplateVariant(TemplateVariant.builder()
-                .subject(TEMPLATE_SUBJECT_DEFAULT)
-                .body(TEMPLATE_BODY_DEFAULT));
+    public static TemplateVariant.TemplateVariantBuilder aTemplateVariant() {
+        return TemplateVariant.builder()
+                .body(TEMPLATE_BODY_DEFAULT)
+                .subject(TEMPLATE_SUBJECT_DEFAULT);
     }
 
     public static Template.TemplateBuilder aTemplate() {
         return Template.builder()
                 .id(BASE_ID)
-                .name(TEMPLATE_NAME)
-                .creationTimestamp(OffsetDateTime.now());
+                .name(TEMPLATE_NAME);
     }
 
     public static void addVariantsToTemplate(Template template) {
-        template.addTemplateVariant(TemplateVariant.builder()
-                .body(TEMPLATE_BODY_DEFAULT)
-                .subject(TEMPLATE_SUBJECT_DEFAULT));
-        template.addTemplateVariant(TemplateVariant.builder()
+        template.addTemplateVariant(aTemplateVariant().build());
+        template.addTemplateVariant(aTemplateVariant()
                 .body(TEMPLATE_BODY_ES_B)
                 .subject(TEMPLATE_SUBJECT_ES_B)
                 .language("es")
-                .treatment("B"));
+                .treatment("B")
+                .build());
     }
 
     public static MessageRequest.MessageRequestBuilder aMessageRequest() {
@@ -74,10 +67,13 @@ public class TestData {
     }
 
     public static Message.MessageBuilder aMessage() {
+        Template template = aTemplate().build();
+        addVariantsToTemplate(template);
         return Message.builder()
                 .id(BASE_ID)
                 .body(TEMPLATE_BODY_DEFAULT)
-                .subject(TEMPLATE_SUBJECT_DEFAULT);
+                .subject(TEMPLATE_SUBJECT_DEFAULT)
+                .templateVariant(template.getTemplateVariants().stream().findFirst().get());
     }
 
 }

--- a/src/test/java/org/codeforamerica/messaging/TestData.java
+++ b/src/test/java/org/codeforamerica/messaging/TestData.java
@@ -8,11 +8,14 @@ import java.util.HashSet;
 import java.util.Map;
 
 public class TestData {
+    public static final String USERNAME = "user";
+    public static final String PASSWORD = "password";
+    public static final Long BASE_ID = 1L;
     public static final String TO_PHONE = "1234567890";
     public static final String TO_EMAIL = "recipient@example.com";
     public static final String FROM_EMAIL = "sender@example.com";
     public static final String PROVIDER_MESSAGE_ID = "some-provider-message-id";
-    public static final String STATUS = "accepted";
+    public static final String STATUS = "any status";
     public static final String TEMPLATE_NAME = "default template name";
     public static final String TEMPLATE_SUBJECT_DEFAULT = "English A Subject: {{placeholder}}";
     public static final String TEMPLATE_BODY_DEFAULT = "English A Body: {{placeholder}}";
@@ -25,7 +28,7 @@ public class TestData {
 
     public static TemplateVariant.TemplateVariantBuilder aDefaultTemplateVariant() {
         return TemplateVariant.builder()
-                .id(1L)
+                .id(BASE_ID)
                 .subject(TEMPLATE_SUBJECT_DEFAULT)
                 .body(TEMPLATE_BODY_DEFAULT)
                 .creationTimestamp(OffsetDateTime.now());
@@ -61,7 +64,7 @@ public class TestData {
 
     public static Template.TemplateBuilder aTemplate() {
         return Template.builder()
-                .id(0L)
+                .id(BASE_ID)
                 .name(TEMPLATE_NAME)
                 .templateVariants(new HashSet<>())
                 .creationTimestamp(OffsetDateTime.now());
@@ -76,27 +79,35 @@ public class TestData {
 
     public static MessageRequest.MessageRequestBuilder aMessageRequest() {
         return MessageRequest.builder()
-                .templateName(TestData.TEMPLATE_NAME)
+                .templateName(TEMPLATE_NAME)
+                // this is to replace "{{placeholder}}" if the placeholder is not being tested
                 .templateParams(Map.of("placeholder", "{{placeholder}}"));
     }
 
     public static SmsMessage.SmsMessageBuilder anSmsMessage() {
         return SmsMessage.builder()
-                .body(TestData.TEMPLATE_BODY_DEFAULT)
-                .toPhone(TestData.TO_PHONE)
+                .body(TEMPLATE_BODY_DEFAULT)
+                .toPhone(TO_PHONE)
                 .fromPhone(TwilioGateway.DEFAULT_FROM_PHONE)
-                .status(TestData.STATUS)
-                .providerMessageId(TestData.PROVIDER_MESSAGE_ID);
+                .status(STATUS)
+                .providerMessageId(PROVIDER_MESSAGE_ID);
     }
 
     public static EmailMessage.EmailMessageBuilder anEmailMessage() {
         return EmailMessage.builder()
-                .body(TestData.TEMPLATE_BODY_DEFAULT)
-                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT)
-                .toEmail(TestData.TO_EMAIL)
-                .fromEmail(TestData.FROM_EMAIL)
-                .status(TestData.STATUS)
-                .providerMessageId(TestData.PROVIDER_MESSAGE_ID);
+                .body(TEMPLATE_BODY_DEFAULT)
+                .subject(TEMPLATE_SUBJECT_DEFAULT)
+                .toEmail(TO_EMAIL)
+                .fromEmail(FROM_EMAIL)
+                .status(STATUS)
+                .providerMessageId(PROVIDER_MESSAGE_ID);
+    }
+
+    public static Message.MessageBuilder aMessage() {
+        return Message.builder()
+                .id(BASE_ID)
+                .body(TEMPLATE_BODY_DEFAULT)
+                .subject(TEMPLATE_SUBJECT_DEFAULT);
     }
 
 }

--- a/src/test/java/org/codeforamerica/messaging/TestData.java
+++ b/src/test/java/org/codeforamerica/messaging/TestData.java
@@ -4,12 +4,9 @@ import org.codeforamerica.messaging.models.*;
 import org.codeforamerica.messaging.providers.twilio.TwilioGateway;
 
 import java.time.OffsetDateTime;
-import java.util.HashSet;
 import java.util.Map;
 
 public class TestData {
-    public static final String USERNAME = "user";
-    public static final String PASSWORD = "password";
     public static final Long BASE_ID = 1L;
     public static final String TO_PHONE = "1234567890";
     public static final String TO_EMAIL = "recipient@example.com";
@@ -26,55 +23,28 @@ public class TestData {
     public static final String TEMPLATE_SUBJECT_ES_B = "Spanish B Subject: {{placeholder}}";
     public static final String TEMPLATE_BODY_ES_B = "Spanish B Body: {{placeholder}}";
 
-    public static TemplateVariant.TemplateVariantBuilder aDefaultTemplateVariant() {
-        return TemplateVariant.builder()
-                .id(BASE_ID)
+    public static TemplateVariant aDefaultTemplateVariant(Template template) {
+        return template.addTemplateVariant(TemplateVariant.builder()
                 .subject(TEMPLATE_SUBJECT_DEFAULT)
-                .body(TEMPLATE_BODY_DEFAULT)
-                .creationTimestamp(OffsetDateTime.now());
-    }
-
-    public static TemplateVariant.TemplateVariantBuilder anEnglishBTemplateVariant() {
-        return TemplateVariant.builder()
-                .id(2L)
-                .subject(TEMPLATE_SUBJECT_EN_B)
-                .body(TEMPLATE_BODY_EN_B)
-                .treatment("B")
-                .creationTimestamp(OffsetDateTime.now());
-    }
-
-    public static TemplateVariant.TemplateVariantBuilder aSpanishATemplateVariant() {
-        return TemplateVariant.builder()
-                .id(3L)
-                .subject(TEMPLATE_SUBJECT_ES_A)
-                .body(TEMPLATE_BODY_ES_A)
-                .language("es")
-                .creationTimestamp(OffsetDateTime.now());
-    }
-
-    public static TemplateVariant.TemplateVariantBuilder aSpanishBTemplateVariant() {
-        return TemplateVariant.builder()
-                .id(4L)
-                .subject(TEMPLATE_SUBJECT_ES_B)
-                .body(TEMPLATE_BODY_ES_B)
-                .language("es")
-                .treatment("B")
-                .creationTimestamp(OffsetDateTime.now());
+                .body(TEMPLATE_BODY_DEFAULT));
     }
 
     public static Template.TemplateBuilder aTemplate() {
         return Template.builder()
                 .id(BASE_ID)
                 .name(TEMPLATE_NAME)
-                .templateVariants(new HashSet<>())
                 .creationTimestamp(OffsetDateTime.now());
     }
 
     public static void addVariantsToTemplate(Template template) {
-        template.addTemplateVariant(aDefaultTemplateVariant().build());
-        template.addTemplateVariant(anEnglishBTemplateVariant().build());
-        template.addTemplateVariant(aSpanishATemplateVariant().build());
-        template.addTemplateVariant(aSpanishBTemplateVariant().build());
+        template.addTemplateVariant(TemplateVariant.builder()
+                .body(TEMPLATE_BODY_DEFAULT)
+                .subject(TEMPLATE_SUBJECT_DEFAULT));
+        template.addTemplateVariant(TemplateVariant.builder()
+                .body(TEMPLATE_BODY_ES_B)
+                .subject(TEMPLATE_SUBJECT_ES_B)
+                .language("es")
+                .treatment("B"));
     }
 
     public static MessageRequest.MessageRequestBuilder aMessageRequest() {

--- a/src/test/java/org/codeforamerica/messaging/TestData.java
+++ b/src/test/java/org/codeforamerica/messaging/TestData.java
@@ -1,0 +1,77 @@
+package org.codeforamerica.messaging;
+
+import org.codeforamerica.messaging.models.Template;
+import org.codeforamerica.messaging.models.TemplateVariant;
+
+import java.time.OffsetDateTime;
+import java.util.HashSet;
+
+public class TestData {
+    public static final String TO_PHONE = "1234567890";
+    public static final String TO_EMAIL = "recipient@example.com";
+    public static final String PROVIDER_MESSAGE_ID = "some-provider-message-id";
+    public static final String STATUS = "accepted";
+    public static final String TEMPLATE_NAME = "default template name";
+    public static final String TEMPLATE_NAME_WITH_VARIANTS = "default template name with variants";
+    public static final String TEMPLATE_SUBJECT_DEFAULT = "English A Subject: {{placeholder}}";
+    public static final String TEMPLATE_BODY_DEFAULT = "English A Body: {{placeholder}}";
+    public static final String TEMPLATE_SUBJECT_EN_B = "English B Subject: {{placeholder}}";
+    public static final String TEMPLATE_BODY_EN_B = "English B Body: {{placeholder}}";
+    public static final String TEMPLATE_SUBJECT_ES_A = "Spanish A Subject: {{placeholder}}";
+    public static final String TEMPLATE_BODY_ES_A = "Spanish A Body: {{placeholder}}";
+    public static final String TEMPLATE_SUBJECT_ES_B = "Spanish B Subject: {{placeholder}}";
+    public static final String TEMPLATE_BODY_ES_B = "Spanish B Body: {{placeholder}}";
+
+    public static TemplateVariant.TemplateVariantBuilder aDefaultTemplateVariant() {
+        return TemplateVariant.builder()
+                .id(1L)
+                .subject(TEMPLATE_SUBJECT_DEFAULT)
+                .body(TEMPLATE_BODY_DEFAULT)
+                .creationTimestamp(OffsetDateTime.now());
+    }
+
+    public static TemplateVariant.TemplateVariantBuilder anEnglishBTemplateVariant() {
+        return TemplateVariant.builder()
+                .id(2L)
+                .subject(TEMPLATE_SUBJECT_EN_B)
+                .body(TEMPLATE_BODY_EN_B)
+                .treatment("B")
+                .creationTimestamp(OffsetDateTime.now());
+    }
+
+    public static TemplateVariant.TemplateVariantBuilder aSpanishATemplateVariant() {
+        return TemplateVariant.builder()
+                .id(3L)
+                .subject(TEMPLATE_SUBJECT_ES_A)
+                .body(TEMPLATE_BODY_ES_A)
+                .language("es")
+                .creationTimestamp(OffsetDateTime.now());
+    }
+
+    public static TemplateVariant.TemplateVariantBuilder aSpanishBTemplateVariant() {
+        return TemplateVariant.builder()
+                .id(4L)
+                .subject(TEMPLATE_SUBJECT_ES_B)
+                .body(TEMPLATE_BODY_ES_B)
+                .language("es")
+                .treatment("B")
+                .creationTimestamp(OffsetDateTime.now());
+    }
+
+    public static Template.TemplateBuilder aTemplate() {
+        return Template.builder()
+                .id(0L)
+                .name(TEMPLATE_NAME)
+                .templateVariants(new HashSet<>())
+                .creationTimestamp(OffsetDateTime.now());
+    }
+
+    public static Template addVariantsToTemplate(Template template) {
+        template.addTemplateVariant(aDefaultTemplateVariant().build());
+        template.addTemplateVariant(anEnglishBTemplateVariant().build());
+        template.addTemplateVariant(aSpanishATemplateVariant().build());
+        template.addTemplateVariant(aSpanishBTemplateVariant().build());
+        return template;
+    }
+
+}

--- a/src/test/java/org/codeforamerica/messaging/controllers/MessageControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/controllers/MessageControllerTest.java
@@ -23,7 +23,6 @@ import java.util.Optional;
 
 import static org.hamcrest.Matchers.endsWith;
 import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 
@@ -56,8 +55,7 @@ public class MessageControllerTest {
         Mockito.when(messageService.getMessage(any()))
                 .thenReturn(Optional.of(TestData.aMessage().toPhone(TestData.TO_PHONE).build()));
 
-        mockMvc.perform(get("/api/v1/messages/" + TestData.BASE_ID)
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
+        mockMvc.perform(get("/api/v1/messages/" + TestData.BASE_ID))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect((MockMvcResultMatchers.content().json(expectedResponse)));
     }
@@ -79,8 +77,7 @@ public class MessageControllerTest {
                         .smsMessage(TestData.anSmsMessage().build())
                         .build()));
 
-        mockMvc.perform(get("/api/v1/messages/" + TestData.BASE_ID)
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
+        mockMvc.perform(get("/api/v1/messages/" + TestData.BASE_ID))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect((MockMvcResultMatchers.content().json(expectedResponse)));
     }

--- a/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.hamcrest.Matchers.containsString;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
@@ -60,30 +59,17 @@ public class TemplateControllerTest {
         Mockito.when(templateService.getTemplateList())
                 .thenReturn(Collections.emptyList());
 
-        mockMvc.perform(get("/api/v1/templates")
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
+        mockMvc.perform(get("/api/v1/templates"))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
     @Test
     @WithMockUser
     public void whenAuthenticatedAndNoTemplatesWithMatchingName_thenNotFound() throws Exception {
-        Mockito.when(templateService.getTemplateByName("something"))
+        Mockito.when(templateService.getTemplateByName(TestData.TEMPLATE_NAME))
                 .thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/v1/templates?name=something")
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
-                .andExpect(MockMvcResultMatchers.status().isNotFound());
-    }
-
-    @Test
-    @WithMockUser
-    public void whenAuthenticatedAndNoTemplatesWithMatchingId_thenNotFound() throws Exception {
-        Mockito.when(templateService.getTemplateById(TestData.BASE_ID))
-                .thenReturn(Optional.empty());
-
-        mockMvc.perform(get("/api/v1/templates/" + TestData.BASE_ID)
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
+        mockMvc.perform(get("/api/v1/templates/" + TestData.TEMPLATE_NAME))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
@@ -93,8 +79,7 @@ public class TemplateControllerTest {
         Mockito.when(templateService.getTemplateList())
                 .thenReturn(List.of(TEMPLATE_WITH_VARIANTS, TEMPLATE_WITHOUT_VARIANTS));
 
-        mockMvc.perform(get("/api/v1/templates")
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
+        mockMvc.perform(get("/api/v1/templates"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITHOUT_VARIANTS)))
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
@@ -110,24 +95,7 @@ public class TemplateControllerTest {
         Mockito.when(templateService.getTemplateByName(TEMPLATE_WITH_VARIANTS.getName()))
                 .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
 
-        mockMvc.perform(get("/api/v1/templates?name=" + TEMPLATE_WITH_VARIANTS.getName())
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
-                .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_DEFAULT)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_ES_B)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_ES_B)));
-    }
-
-    @Test
-    @WithMockUser
-    public void whenAuthenticatedAndTemplateWithMatchingIdExists_thenReturnTemplateAndVariants() throws Exception {
-        Mockito.when(templateService.getTemplateById(TEMPLATE_WITH_VARIANTS.getId()))
-                .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
-
-        mockMvc.perform(get("/api/v1/templates/" + TEMPLATE_WITH_VARIANTS.getId())
-                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
+        mockMvc.perform(get("/api/v1/templates/" + TEMPLATE_WITH_VARIANTS.getName()))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
                 .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))

--- a/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
@@ -77,35 +77,25 @@ public class TemplateControllerTest {
         String expectedResponse = """
                 [
                     {
-                        "id":1,
                         "name":"Template name with variants",
                         "templateVariants":[
                             {
-                                "id":null,
                                 "language":"en",
                                 "treatment":"A",
                                 "subject":"English A Subject: {{placeholder}}",
-                                "body":"English A Body: {{placeholder}}",
-                                "updateTimestamp":null,
-                                "templateName":"Template name with variants"
+                                "body":"English A Body: {{placeholder}}"
                             },
                             {
-                                "id":null,
                                 "language":"es",
                                 "treatment":"B",
                                 "subject":"Spanish B Subject: {{placeholder}}",
-                                "body":"Spanish B Body: {{placeholder}}",
-                                "updateTimestamp":null,
-                                "templateName":"Template name with variants"
+                                "body":"Spanish B Body: {{placeholder}}"
                             }
                         ],
-                        "updateTimestamp":null
                     },
                     {
-                        "id":1,
                         "name":"Template name without variants",
-                        "templateVariants":[],
-                        "updateTimestamp":null
+                        "templateVariants":[]
                     }
                 ]
                 """;
@@ -123,29 +113,21 @@ public class TemplateControllerTest {
     public void whenAuthenticatedAndTemplateWithMatchingNameExists_thenReturnTemplateAndVariants() throws Exception {
         String expectedResponse = """
                 {
-                    "id":1,
                     "name":"Template name with variants",
                     "templateVariants":[
                         {
-                            "id":null,
                             "language":"en",
                             "treatment":"A",
                             "subject":"English A Subject: {{placeholder}}",
-                            "body":"English A Body: {{placeholder}}",
-                            "updateTimestamp":null,
-                            "templateName":"Template name with variants"
+                            "body":"English A Body: {{placeholder}}"
                         },
                         {
-                            "id":null,
                             "language":"es",
                             "treatment":"B",
                             "subject":"Spanish B Subject: {{placeholder}}",
-                            "body":"Spanish B Body: {{placeholder}}",
-                            "updateTimestamp":null,
-                            "templateName":"Template name with variants"
+                            "body":"Spanish B Body: {{placeholder}}"
                         }
-                    ],
-                    "updateTimestamp":null
+                    ]
                 }
                 """;
 

--- a/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
@@ -61,7 +61,7 @@ public class TemplateControllerTest {
                 .thenReturn(Collections.emptyList());
 
         mockMvc.perform(get("/api/v1/templates")
-                        .with(httpBasic("user", "password")))
+                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
@@ -72,18 +72,18 @@ public class TemplateControllerTest {
                 .thenReturn(Optional.empty());
 
         mockMvc.perform(get("/api/v1/templates?name=something")
-                        .with(httpBasic("user", "password")))
+                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
     @Test
     @WithMockUser
     public void whenAuthenticatedAndNoTemplatesWithMatchingId_thenNotFound() throws Exception {
-        Mockito.when(templateService.getTemplateById(1L))
+        Mockito.when(templateService.getTemplateById(TestData.BASE_ID))
                 .thenReturn(Optional.empty());
 
-        mockMvc.perform(get("/api/v1/templates/1")
-                        .with(httpBasic("user", "password")))
+        mockMvc.perform(get("/api/v1/templates/" + TestData.BASE_ID)
+                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
                 .andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
@@ -94,7 +94,7 @@ public class TemplateControllerTest {
                 .thenReturn(List.of(TEMPLATE_WITH_VARIANTS, TEMPLATE_WITHOUT_VARIANTS));
 
         mockMvc.perform(get("/api/v1/templates")
-                        .with(httpBasic("user", "password")))
+                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITHOUT_VARIANTS)))
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
@@ -111,7 +111,7 @@ public class TemplateControllerTest {
                 .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
 
         mockMvc.perform(get("/api/v1/templates?name=" + TEMPLATE_WITH_VARIANTS.getName())
-                        .with(httpBasic("user", "password")))
+                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
                 .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
@@ -127,7 +127,7 @@ public class TemplateControllerTest {
                 .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
 
         mockMvc.perform(get("/api/v1/templates/" + TEMPLATE_WITH_VARIANTS.getId())
-                        .with(httpBasic("user", "password")))
+                        .with(httpBasic(TestData.USERNAME, TestData.PASSWORD)))
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
                 .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))

--- a/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
@@ -20,9 +20,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 @WebMvcTest(TemplateController.class)
 @Import(SecurityConfiguration.class)
@@ -76,32 +74,87 @@ public class TemplateControllerTest {
     @Test
     @WithMockUser
     public void whenAuthenticatedAndTemplatesExist_thenReturnTemplatesAndVariants() throws Exception {
+        String expectedResponse = """
+                [
+                    {
+                        "id":1,
+                        "name":"Template name with variants",
+                        "templateVariants":[
+                            {
+                                "id":null,
+                                "language":"en",
+                                "treatment":"A",
+                                "subject":"English A Subject: {{placeholder}}",
+                                "body":"English A Body: {{placeholder}}",
+                                "updateTimestamp":null,
+                                "templateName":"Template name with variants"
+                            },
+                            {
+                                "id":null,
+                                "language":"es",
+                                "treatment":"B",
+                                "subject":"Spanish B Subject: {{placeholder}}",
+                                "body":"Spanish B Body: {{placeholder}}",
+                                "updateTimestamp":null,
+                                "templateName":"Template name with variants"
+                            }
+                        ],
+                        "updateTimestamp":null
+                    },
+                    {
+                        "id":1,
+                        "name":"Template name without variants",
+                        "templateVariants":[],
+                        "updateTimestamp":null
+                    }
+                ]
+                """;
+
         Mockito.when(templateService.getTemplateList())
                 .thenReturn(List.of(TEMPLATE_WITH_VARIANTS, TEMPLATE_WITHOUT_VARIANTS));
 
         mockMvc.perform(get("/api/v1/templates"))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(content().string(containsString(TEMPLATE_NAME_WITHOUT_VARIANTS)))
-                .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_DEFAULT)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_ES_B)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_ES_B)));
+                .andExpect((MockMvcResultMatchers.content().json(expectedResponse)));
     }
 
     @Test
     @WithMockUser
     public void whenAuthenticatedAndTemplateWithMatchingNameExists_thenReturnTemplateAndVariants() throws Exception {
+        String expectedResponse = """
+                {
+                    "id":1,
+                    "name":"Template name with variants",
+                    "templateVariants":[
+                        {
+                            "id":null,
+                            "language":"en",
+                            "treatment":"A",
+                            "subject":"English A Subject: {{placeholder}}",
+                            "body":"English A Body: {{placeholder}}",
+                            "updateTimestamp":null,
+                            "templateName":"Template name with variants"
+                        },
+                        {
+                            "id":null,
+                            "language":"es",
+                            "treatment":"B",
+                            "subject":"Spanish B Subject: {{placeholder}}",
+                            "body":"Spanish B Body: {{placeholder}}",
+                            "updateTimestamp":null,
+                            "templateName":"Template name with variants"
+                        }
+                    ],
+                    "updateTimestamp":null
+                }
+                """;
+
         Mockito.when(templateService.getTemplateByName(TEMPLATE_WITH_VARIANTS.getName()))
                 .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
 
         mockMvc.perform(get("/api/v1/templates/" + TEMPLATE_WITH_VARIANTS.getName()))
                 .andExpect(MockMvcResultMatchers.status().isOk())
-                .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_DEFAULT)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_ES_B)))
-                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_ES_B)));
+                .andExpect((MockMvcResultMatchers.content().json(expectedResponse)));
     }
 
 }

--- a/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/controllers/TemplateControllerTest.java
@@ -1,0 +1,139 @@
+package org.codeforamerica.messaging.controllers;
+
+
+import org.codeforamerica.messaging.TestData;
+import org.codeforamerica.messaging.config.SecurityConfiguration;
+import org.codeforamerica.messaging.models.Template;
+import org.codeforamerica.messaging.services.TemplateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+
+@WebMvcTest(TemplateController.class)
+@Import(SecurityConfiguration.class)
+public class TemplateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private TemplateService templateService;
+
+    private final String TEMPLATE_NAME_WITHOUT_VARIANTS = "Template name without variants";
+    private final String TEMPLATE_NAME_WITH_VARIANTS = "Template name with variants";
+    private final Template TEMPLATE_WITHOUT_VARIANTS = TestData.aTemplate()
+            .name(TEMPLATE_NAME_WITHOUT_VARIANTS)
+            .build();
+    private final Template TEMPLATE_WITH_VARIANTS = TestData.aTemplate()
+            .name(TEMPLATE_NAME_WITH_VARIANTS)
+            .build();
+
+    @BeforeEach
+    void setup() {
+        TestData.addVariantsToTemplate(TEMPLATE_WITH_VARIANTS);
+    }
+
+    @Test
+    public void whenUnauthenticated_thenUnauthorized() throws Exception {
+        mockMvc.perform(get("/api/v1/templates"))
+                .andExpect(MockMvcResultMatchers.status().isUnauthorized());
+    }
+
+    @Test
+    @WithMockUser
+    public void whenAuthenticatedAndNoTemplates_thenNotFound() throws Exception {
+        Mockito.when(templateService.getTemplateList())
+                .thenReturn(Collections.emptyList());
+
+        mockMvc.perform(get("/api/v1/templates")
+                        .with(httpBasic("user", "password")))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    public void whenAuthenticatedAndNoTemplatesWithMatchingName_thenNotFound() throws Exception {
+        Mockito.when(templateService.getTemplateByName("something"))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/templates?name=something")
+                        .with(httpBasic("user", "password")))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    public void whenAuthenticatedAndNoTemplatesWithMatchingId_thenNotFound() throws Exception {
+        Mockito.when(templateService.getTemplateById(1L))
+                .thenReturn(Optional.empty());
+
+        mockMvc.perform(get("/api/v1/templates/1")
+                        .with(httpBasic("user", "password")))
+                .andExpect(MockMvcResultMatchers.status().isNotFound());
+    }
+
+    @Test
+    @WithMockUser
+    public void whenAuthenticatedAndTemplatesExist_thenReturnTemplatesAndVariants() throws Exception {
+        Mockito.when(templateService.getTemplateList())
+                .thenReturn(List.of(TEMPLATE_WITH_VARIANTS, TEMPLATE_WITHOUT_VARIANTS));
+
+        mockMvc.perform(get("/api/v1/templates")
+                        .with(httpBasic("user", "password")))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(content().string(containsString(TEMPLATE_NAME_WITHOUT_VARIANTS)))
+                .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_DEFAULT)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_ES_B)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_ES_B)));
+    }
+
+    @Test
+    @WithMockUser
+    public void whenAuthenticatedAndTemplateWithMatchingNameExists_thenReturnTemplateAndVariants() throws Exception {
+        Mockito.when(templateService.getTemplateByName(TEMPLATE_WITH_VARIANTS.getName()))
+                .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
+
+        mockMvc.perform(get("/api/v1/templates?name=" + TEMPLATE_WITH_VARIANTS.getName())
+                        .with(httpBasic("user", "password")))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_DEFAULT)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_ES_B)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_ES_B)));
+    }
+
+    @Test
+    @WithMockUser
+    public void whenAuthenticatedAndTemplateWithMatchingIdExists_thenReturnTemplateAndVariants() throws Exception {
+        Mockito.when(templateService.getTemplateById(TEMPLATE_WITH_VARIANTS.getId()))
+                .thenReturn(Optional.of(TEMPLATE_WITH_VARIANTS));
+
+        mockMvc.perform(get("/api/v1/templates/" + TEMPLATE_WITH_VARIANTS.getId())
+                        .with(httpBasic("user", "password")))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(content().string(containsString(TEMPLATE_NAME_WITH_VARIANTS)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_DEFAULT)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_DEFAULT)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_SUBJECT_ES_B)))
+                .andExpect(content().string(containsString(TestData.TEMPLATE_BODY_ES_B)));
+    }
+
+}

--- a/src/test/java/org/codeforamerica/messaging/models/MessageRequestTest.java
+++ b/src/test/java/org/codeforamerica/messaging/models/MessageRequestTest.java
@@ -75,7 +75,7 @@ class MessageRequestTest {
         messageRepository.save(message);
         SmsMessage smsMessage = SmsMessage.builder()
                 .toPhone(TestData.TO_PHONE)
-                .fromPhone(TwilioGateway.DEFAULT_NUMBER)
+                .fromPhone(TwilioGateway.DEFAULT_FROM_PHONE)
                 .body(TestData.TEMPLATE_BODY_DEFAULT)
                 .status(TestData.STATUS)
                 .providerMessageId(TestData.PROVIDER_MESSAGE_ID)

--- a/src/test/java/org/codeforamerica/messaging/models/MessageRequestTest.java
+++ b/src/test/java/org/codeforamerica/messaging/models/MessageRequestTest.java
@@ -59,8 +59,9 @@ class MessageRequestTest {
     @Test
     public void persistence() {
         Template template = TestData.aTemplate().build();
-        TemplateVariant templateVariant = TestData.aDefaultTemplateVariant().build();
-        template.addTemplateVariant(templateVariant);
+        template.addTemplateVariant(TemplateVariant.builder()
+                .body(TestData.TEMPLATE_BODY_DEFAULT)
+                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT));
         template = templateRepository.save(template);
         Message message = TestData.aMessage()
                 .toPhone(TestData.TO_PHONE)

--- a/src/test/java/org/codeforamerica/messaging/models/MessageRequestTest.java
+++ b/src/test/java/org/codeforamerica/messaging/models/MessageRequestTest.java
@@ -59,14 +59,12 @@ class MessageRequestTest {
     @Test
     public void persistence() {
         Template template = TestData.aTemplate().build();
-        template.addTemplateVariant(TemplateVariant.builder()
-                .body(TestData.TEMPLATE_BODY_DEFAULT)
-                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT));
+        TestData.addVariantsToTemplate(template);
         template = templateRepository.save(template);
         Message message = TestData.aMessage()
                 .toPhone(TestData.TO_PHONE)
                 .toEmail(TestData.TO_EMAIL)
-                .templateVariant(template.getTemplateVariants().get(0))
+                .templateVariant(template.getTemplateVariants().stream().findFirst().get())
                 .build();
         message = messageRepository.save(message);
         SmsMessage smsMessage = TestData.anSmsMessage().build();

--- a/src/test/java/org/codeforamerica/messaging/models/TemplateVariantTest.java
+++ b/src/test/java/org/codeforamerica/messaging/models/TemplateVariantTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class TemplateVariantTest {
     @Test
     void whenInputHasTemplateParams_thenTemplateUsesParams() throws IOException {
-        TemplateVariant templateVariant = TestData.aDefaultTemplateVariant(TestData.aTemplate().build());
+        TemplateVariant templateVariant = TestData.aTemplateVariant().build();
         Map<String, Object> templateParams = Map.of("placeholder", "testing placeholder");
 
         Assertions.assertEquals("English A Subject: testing placeholder",

--- a/src/test/java/org/codeforamerica/messaging/models/TemplateVariantTest.java
+++ b/src/test/java/org/codeforamerica/messaging/models/TemplateVariantTest.java
@@ -1,11 +1,8 @@
 package org.codeforamerica.messaging.models;
 
-import org.codeforamerica.messaging.repositories.TemplateRepository;
-import org.junit.jupiter.api.AfterEach;
+import org.codeforamerica.messaging.TestData;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
@@ -13,39 +10,14 @@ import java.util.Map;
 
 @SpringBootTest
 public class TemplateVariantTest {
-    @Autowired
-    private TemplateRepository templateRepository;
-
-
-    private final String SUBJECT = "Hi {{recipient_name}}! First SMS ever!";
-    private final String BODY = "Merry Christmas {{recipient_name}}! From {{sender_name}}";
-    private final Template TEMPLATE = Template.builder()
-            .name("test")
-            .build();
-    private final TemplateVariant TEMPLATE_VARIANT = TemplateVariant.builder()
-            .body(BODY)
-            .subject(SUBJECT)
-            .template(TEMPLATE)
-            .build();
-
-    @BeforeEach
-    void setup() {
-        templateRepository.save(TEMPLATE);
-    }
-
-    @AfterEach
-    void tearDown() {
-        templateRepository.deleteAll();
-    }
-
     @Test
     void whenInputHasTemplateParams_thenTemplateUsesParams() throws IOException {
-        Map<String, Object> templateParams = Map.of("recipient_name", "Jarvis", "sender_name", "Papworth");
+        TemplateVariant templateVariant = TestData.aDefaultTemplateVariant().build();
+        Map<String, Object> templateParams = Map.of("placeholder", "testing placeholder");
 
-        Assertions.assertEquals("Hi Jarvis! First SMS ever!",
-                TEMPLATE_VARIANT.build(TemplateVariant::getSubject, templateParams));
-        Assertions.assertEquals("Merry Christmas Jarvis! From Papworth",
-                TEMPLATE_VARIANT.build(TemplateVariant::getBody, templateParams));
+        Assertions.assertEquals("English A Subject: testing placeholder",
+                templateVariant.build(TemplateVariant::getSubject, templateParams));
+        Assertions.assertEquals("English A Body: testing placeholder",
+                templateVariant.build(TemplateVariant::getBody, templateParams));
     }
-
 }

--- a/src/test/java/org/codeforamerica/messaging/models/TemplateVariantTest.java
+++ b/src/test/java/org/codeforamerica/messaging/models/TemplateVariantTest.java
@@ -12,7 +12,7 @@ import java.util.Map;
 public class TemplateVariantTest {
     @Test
     void whenInputHasTemplateParams_thenTemplateUsesParams() throws IOException {
-        TemplateVariant templateVariant = TestData.aDefaultTemplateVariant().build();
+        TemplateVariant templateVariant = TestData.aDefaultTemplateVariant(TestData.aTemplate().build());
         Map<String, Object> templateParams = Map.of("placeholder", "testing placeholder");
 
         Assertions.assertEquals("English A Subject: testing placeholder",

--- a/src/test/java/org/codeforamerica/messaging/providers/twilio/MailgunCallbackControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/providers/twilio/MailgunCallbackControllerTest.java
@@ -1,7 +1,7 @@
 package org.codeforamerica.messaging.providers.twilio;
 
+import org.codeforamerica.messaging.TestData;
 import org.codeforamerica.messaging.config.SecurityConfiguration;
-import org.codeforamerica.messaging.models.EmailMessage;
 import org.codeforamerica.messaging.providers.mailgun.MailgunCallbackController;
 import org.codeforamerica.messaging.repositories.EmailMessageRepository;
 import org.junit.jupiter.api.Test;
@@ -27,8 +27,8 @@ public class MailgunCallbackControllerTest {
 
     @Test
     public void postEmailStatusSuccess() throws Exception {
-        Mockito.when(emailMessageRepository.findFirstByProviderMessageId("message_id"))
-                .thenReturn(EmailMessage.builder().providerMessageId("message_id").build());
+        Mockito.when(emailMessageRepository.findFirstByProviderMessageId(TestData.PROVIDER_MESSAGE_ID))
+                .thenReturn(TestData.anEmailMessage().build());
 
         mockMvc.perform(post("/mailgun_callbacks/status")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -38,12 +38,12 @@ public class MailgunCallbackControllerTest {
                                             "event": "delivered",
                                             "message": {
                                               "headers": {
-                                                "message-id": "message_id"
+                                                "message-id": "%s"
                                               }
                                             }
                                         }
                                     }
-                                """))
+                                """.formatted(TestData.PROVIDER_MESSAGE_ID)))
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }
 

--- a/src/test/java/org/codeforamerica/messaging/providers/twilio/TwilioCallbackControllerTest.java
+++ b/src/test/java/org/codeforamerica/messaging/providers/twilio/TwilioCallbackControllerTest.java
@@ -1,7 +1,7 @@
 package org.codeforamerica.messaging.providers.twilio;
 
+import org.codeforamerica.messaging.TestData;
 import org.codeforamerica.messaging.config.SecurityConfiguration;
-import org.codeforamerica.messaging.models.SmsMessage;
 import org.codeforamerica.messaging.repositories.SmsMessageRepository;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -28,12 +28,12 @@ public class TwilioCallbackControllerTest {
     @Test
     public void postSmsStatusSuccessUnauthenticated() throws Exception {
         Mockito.when(smsMessageRepository.findFirstByProviderMessageId(any()))
-                .thenReturn(SmsMessage.builder().providerMessageId("message_id").build());
+                .thenReturn(TestData.anSmsMessage().build());
 
         mockMvc.perform(post("/twilio_callbacks/status")
                         .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
-                        .param("MessageSid", "SM13234")
-                        .param("From", "1234567890")
+                        .param("MessageSid", TestData.PROVIDER_MESSAGE_ID)
+                        .param("From", TwilioGateway.DEFAULT_FROM_PHONE)
                         .param("MessageStatus", "delivered"))
                 .andExpect(MockMvcResultMatchers.status().isOk());
     }

--- a/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
+++ b/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
@@ -53,39 +53,32 @@ class MessageServiceTest {
 
     @Test
     void whenOnlyPhone_thenOnlySmsServiceCalled() {
-        MessageRequest messageRequest = TestData.aMessageRequest()
-                .toPhone(TestData.TO_PHONE)
-                .build();
-        Message message = messageService.saveMessage(messageRequest);
+        Message message = messageService.saveMessage(TestData.aMessageRequest().toPhone(TestData.TO_PHONE).build());
 
         messageService.sendMessage(message.getId());
-        Mockito.verify(smsService).sendSmsMessage(messageRequest.getToPhone(), TestData.TEMPLATE_BODY_DEFAULT);
+        Mockito.verify(smsService).sendSmsMessage(TestData.TO_PHONE, TestData.TEMPLATE_BODY_DEFAULT);
         Mockito.verify(emailService, Mockito.never()).sendEmailMessage(Mockito.any(), Mockito.any(), Mockito.any());
     }
 
     @Test
     void whenOnlyEmail_thenOnlyEmailServiceCalled() {
-        MessageRequest messageRequest = TestData.aMessageRequest()
-                .toEmail(TestData.TO_EMAIL)
-                .build();
-        Message message = messageService.saveMessage(messageRequest);
+        Message message = messageService.saveMessage(TestData.aMessageRequest().toEmail(TestData.TO_EMAIL).build());
 
         messageService.sendMessage(message.getId());
         Mockito.verify(smsService, Mockito.never()).sendSmsMessage(Mockito.anyString(), Mockito.anyString());
-        Mockito.verify(emailService).sendEmailMessage(message.getToEmail(), TestData.TEMPLATE_BODY_DEFAULT, TestData.TEMPLATE_SUBJECT_DEFAULT);
+        Mockito.verify(emailService).sendEmailMessage(TestData.TO_EMAIL, TestData.TEMPLATE_BODY_DEFAULT, TestData.TEMPLATE_SUBJECT_DEFAULT);
     }
 
     @Test
     void whenBothPhoneAndEmail_thenBothServicesCalled() {
-        MessageRequest messageRequest = TestData.aMessageRequest()
+        Message message = messageService.saveMessage(TestData.aMessageRequest()
                 .toPhone(TestData.TO_PHONE)
                 .toEmail(TestData.TO_EMAIL)
-                .build();
-        Message message = messageService.saveMessage(messageRequest);
+                .build());
 
         messageService.sendMessage(message.getId());
-        Mockito.verify(smsService).sendSmsMessage(messageRequest.getToPhone(), TestData.TEMPLATE_BODY_DEFAULT);
-        Mockito.verify(emailService).sendEmailMessage(message.getToEmail(), TestData.TEMPLATE_BODY_DEFAULT, TestData.TEMPLATE_SUBJECT_DEFAULT);
+        Mockito.verify(smsService).sendSmsMessage(TestData.TO_PHONE, TestData.TEMPLATE_BODY_DEFAULT);
+        Mockito.verify(emailService).sendEmailMessage(TestData.TO_EMAIL, TestData.TEMPLATE_BODY_DEFAULT, TestData.TEMPLATE_SUBJECT_DEFAULT);
     }
 
     @Test

--- a/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
+++ b/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
@@ -41,7 +41,15 @@ class MessageServiceTest {
     @BeforeEach
     void setup() {
         Template template = TestData.aTemplate().build();
-        TestData.addVariantsToTemplate(template);
+        template = templateRepository.save(template);
+        template.addTemplateVariant(TemplateVariant.builder()
+                .body(TestData.TEMPLATE_BODY_DEFAULT)
+                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT));
+        template.addTemplateVariant(TemplateVariant.builder()
+                .body(TestData.TEMPLATE_BODY_ES_B)
+                .subject(TestData.TEMPLATE_SUBJECT_ES_B)
+                .language("es")
+                .treatment("B"));
         templateRepository.save(template);
     }
 

--- a/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
+++ b/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
@@ -53,10 +53,8 @@ class MessageServiceTest {
 
     @Test
     void whenOnlyPhone_thenOnlySmsServiceCalled() {
-        MessageRequest messageRequest = MessageRequest.builder()
+        MessageRequest messageRequest = TestData.aMessageRequest()
                 .toPhone(TestData.TO_PHONE)
-                .templateName(TestData.TEMPLATE_NAME)
-                .templateParams(Map.of("placeholder", "{{placeholder}}"))
                 .build();
         Message message = messageService.saveMessage(messageRequest);
 
@@ -67,10 +65,8 @@ class MessageServiceTest {
 
     @Test
     void whenOnlyEmail_thenOnlyEmailServiceCalled() {
-        MessageRequest messageRequest = MessageRequest.builder()
+        MessageRequest messageRequest = TestData.aMessageRequest()
                 .toEmail(TestData.TO_EMAIL)
-                .templateName(TestData.TEMPLATE_NAME)
-                .templateParams(Map.of("placeholder", "{{placeholder}}"))
                 .build();
         Message message = messageService.saveMessage(messageRequest);
 
@@ -81,11 +77,9 @@ class MessageServiceTest {
 
     @Test
     void whenBothPhoneAndEmail_thenBothServicesCalled() {
-        MessageRequest messageRequest = MessageRequest.builder()
+        MessageRequest messageRequest = TestData.aMessageRequest()
                 .toPhone(TestData.TO_PHONE)
                 .toEmail(TestData.TO_EMAIL)
-                .templateName(TestData.TEMPLATE_NAME)
-                .templateParams(Map.of("placeholder", "{{placeholder}}"))
                 .build();
         Message message = messageService.saveMessage(messageRequest);
 
@@ -96,35 +90,20 @@ class MessageServiceTest {
 
     @Test
     void whenScheduledWithBothPhoneAndEmail_thenBothServicesCalledAfterScheduleDelay() {
-        MessageRequest messageRequest = MessageRequest.builder()
+        MessageRequest messageRequest = TestData.aMessageRequest()
                 .toPhone(TestData.TO_PHONE)
                 .toEmail(TestData.TO_EMAIL)
-                .templateName(TestData.TEMPLATE_NAME)
-                .templateParams(Map.of("placeholder", "{{placeholder}}"))
                 .sendAt(OffsetDateTime.now().plusSeconds(20))
                 .build();
-        SmsMessage smsMessage = SmsMessage.builder()
-                .body(TestData.TEMPLATE_BODY_DEFAULT)
-                .toPhone(messageRequest.getToPhone())
-                .fromPhone(TestData.TO_PHONE)
-                .status(TestData.STATUS)
-                .providerMessageId(TestData.PROVIDER_MESSAGE_ID)
-                .build();
-        smsMessageRepository.save(smsMessage);
 
+        SmsMessage smsMessage = TestData.anSmsMessage().build();
+        smsMessage = smsMessageRepository.save(smsMessage);
         Mockito.when(smsService.sendSmsMessage(Mockito.any(), Mockito.any())).thenReturn(smsMessage);
 
-        EmailMessage emailMessage = EmailMessage.builder()
-                .body(TestData.TEMPLATE_BODY_DEFAULT)
-                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT)
-                .toEmail(messageRequest.getToEmail())
-                .fromEmail(TestData.TO_EMAIL)
-                .status(TestData.STATUS)
-                .providerMessageId(TestData.PROVIDER_MESSAGE_ID)
-                .build();
+        EmailMessage emailMessage = TestData.anEmailMessage().build();
+        emailMessage = emailMessageRepository.save(emailMessage);
         Mockito.when(emailService.sendEmailMessage(Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(emailMessage);
-        emailMessageRepository.save(emailMessage);
 
         Message message = messageService.scheduleMessage(messageRequest);
         await().atMost(60, SECONDS).until(() -> {
@@ -135,10 +114,9 @@ class MessageServiceTest {
 
     @Test
     void whenMessageRequestHasLanguageAndTreatment_thenValuesAreUsedToSelectTemplateVariant() {
-        MessageRequest messageRequest = MessageRequest.builder()
+        MessageRequest messageRequest = TestData.aMessageRequest()
                 .toPhone(TestData.TO_PHONE)
                 .toEmail(TestData.TO_EMAIL)
-                .templateName(TestData.TEMPLATE_NAME)
                 .templateParams(Map.of(
                         "language", "es",
                         "treatment", "B",

--- a/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
+++ b/src/test/java/org/codeforamerica/messaging/services/MessageServiceTest.java
@@ -42,14 +42,7 @@ class MessageServiceTest {
     void setup() {
         Template template = TestData.aTemplate().build();
         template = templateRepository.save(template);
-        template.addTemplateVariant(TemplateVariant.builder()
-                .body(TestData.TEMPLATE_BODY_DEFAULT)
-                .subject(TestData.TEMPLATE_SUBJECT_DEFAULT));
-        template.addTemplateVariant(TemplateVariant.builder()
-                .body(TestData.TEMPLATE_BODY_ES_B)
-                .subject(TestData.TEMPLATE_SUBJECT_ES_B)
-                .language("es")
-                .treatment("B"));
+        TestData.addVariantsToTemplate(template);
         templateRepository.save(template);
     }
 


### PR DESCRIPTION
Unit tests were getting repetitive so I factored out a class called `TestData`. Right now there are builders for all common objects in the same class which may become cumbersome in the future and warrant splitting them all out.