### PR TITLE
Open access to all endpoints by default

### DIFF
--- a/src/main/java/org/codeforamerica/messaging/config/SecurityConfiguration.java
+++ b/src/main/java/org/codeforamerica/messaging/config/SecurityConfiguration.java
@@ -18,8 +18,7 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/v1/**").authenticated()
                         .requestMatchers("/error/**").authenticated()
-                        .requestMatchers("/public/**").permitAll()
-                        .anyRequest().denyAll()
+                        .anyRequest().permitAll()
                 )
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .httpBasic(withDefaults());


### PR DESCRIPTION
Being closed by default is making it hard to diagnose issues in this early stage. We will revisit this decision.