### PR TITLE
Fix a bug when deleting a single TemplateVariant

### DIFF
--- a/src/main/java/org/codeforamerica/messaging/models/Template.java
+++ b/src/main/java/org/codeforamerica/messaging/models/Template.java
@@ -71,8 +71,7 @@ public class Template {
         if (this.getTemplateVariants().size() == 1) {
             throw new Exception("Cannot delete last variant on template - delete parent template instead");
         }
-        templateVariant.setTemplate(null);
-        this.getTemplateVariants().remove(templateVariant);
+        this.getTemplateVariants().removeIf(tv -> tv.equals(templateVariant));
     }
 
     public Optional<TemplateVariant> getTemplateVariant(String language, String treatment) {


### PR DESCRIPTION
For future education about bugs relating to `PersistentSets`, see this post: https://stackoverflow.com/a/47968974